### PR TITLE
Waymo End 2 End dataset support

### DIFF
--- a/hptr_modules/data_modules/data_h5_waymo_e2e.py
+++ b/hptr_modules/data_modules/data_h5_waymo_e2e.py
@@ -19,11 +19,6 @@ class DatasetBase(Dataset[Dict[str, np.ndarray]]):
 
 
 class DatasetTrain(DatasetBase):
-    """
-    The waymo 9-sec trainging.h5 is repetitive, start at {0, 2, 4, 5, 6, 8, 10} seconds within the 20-sec episode.
-    Always train with the whole training.h5 dataset.
-    limit_train_batches just for controlling the validation frequency.
-    """
 
     def __getitem__(self, idx: int) -> Dict[str, np.ndarray]:
         idx = np.random.randint(self.dataset_len)

--- a/hptr_modules/data_modules/data_h5_wod_e2e.py
+++ b/hptr_modules/data_modules/data_h5_wod_e2e.py
@@ -1,0 +1,217 @@
+# Licensed under the CC BY-NC 4.0 license (https://creativecommons.org/licenses/by-nc/4.0/)
+from typing import Optional, Dict, Any, Tuple
+from pytorch_lightning import LightningDataModule
+from torch.utils.data import DataLoader, Dataset
+import numpy as np
+import h5py
+
+
+class DatasetBase(Dataset[Dict[str, np.ndarray]]):
+    def __init__(self, filepath: str, tensor_size: Dict[str, Tuple]) -> None:
+        super().__init__()
+        self.tensor_size = tensor_size
+        self.filepath = filepath
+        with h5py.File(self.filepath, "r", libver="latest", swmr=True) as hf:
+            self.dataset_len = int(hf.attrs["data_len"])
+
+    def __len__(self) -> int:
+        return self.dataset_len
+
+
+class DatasetTrain(DatasetBase):
+    """
+    The waymo 9-sec trainging.h5 is repetitive, start at {0, 2, 4, 5, 6, 8, 10} seconds within the 20-sec episode.
+    Always train with the whole training.h5 dataset.
+    limit_train_batches just for controlling the validation frequency.
+    """
+
+    def __getitem__(self, idx: int) -> Dict[str, np.ndarray]:
+        idx = np.random.randint(self.dataset_len)
+        idx_key = str(idx)
+        out_dict = {"episode_idx": idx}
+        with h5py.File(self.filepath, "r", libver="latest", swmr=True) as hf:
+            for k in self.tensor_size.keys():
+                out_dict[k] = np.ascontiguousarray(hf[idx_key][k])
+        return out_dict
+
+
+class DatasetVal(DatasetBase):
+    # for validation.h5 and testing.h5
+    def __getitem__(self, idx: int) -> Dict[str, np.ndarray]:
+        idx_key = str(idx)
+        with h5py.File(self.filepath, "r", libver="latest", swmr=True) as hf:
+            out_dict = {
+                "episode_idx": idx,
+                "scenario_id": hf[idx_key].attrs["scenario_id"],
+            }
+            for k, _size in self.tensor_size.items():
+                out_dict[k] = np.ascontiguousarray(hf[idx_key][k])
+                if out_dict[k].shape != _size:
+                    assert "agent" in k
+                    out_dict[k] = np.ones(_size, dtype=out_dict[k].dtype)
+        return out_dict
+
+
+class DataH5womd(LightningDataModule):
+    def __init__(
+        self,
+        data_dir: str,
+        filename_train: str = "training",
+        filename_val: str = "validation",
+        filename_test: str = "testing",
+        batch_size: int = 3,
+        num_workers: int = 4,
+    ) -> None:
+        super().__init__()
+        self.interactive_challenge = (
+            "interactive" in filename_val or "interactive" in filename_test
+        )
+
+        self.path_train_h5 = f"{data_dir}/{filename_train}.h5"
+        self.path_val_h5 = f"{data_dir}/{filename_val}.h5"
+        self.path_test_h5 = f"{data_dir}/{filename_test}.h5"
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+
+        self.tensor_size_train = {
+            # front left camera
+            "agent/front_left/img": (1079, 972, 3),  # float32
+            "agent/front_left/calib/intr": (9,),  # float32
+            "agent/front_left/calib/extr": (16,), # float32
+            # front camera
+            "agent/front/img": (1079, 972, 3),  # float32
+            "agent/front/calib/intr": (9,),  # float32
+            "agent/front/calib/extr": (16,), # float32
+            # front right camera
+            "agent/front_right/img": (1079, 972, 3),  # float32
+            "agent/front_right/calib/intr": (9,),  # float32
+            "agent/front_right/calib/extr": (16,), # float32
+            # side left camera
+            "agent/side_left/img": (1079, 972, 3),  # float32
+            "agent/side_left/calib/intr": (9,),  # float32
+            "agent/side_left/calib/extr": (16,), # float32
+            # side right camera
+            "agent/side_right/img": (1079, 972, 3),  # float32
+            "agent/side_right/calib/intr": (9,),  # float32
+            "agent/side_right/calib/extr": (16,), # float32
+            # rear left camera
+            "agent/rear_left/img": (587, 972, 3),  # float32
+            "agent/rear_left/calib/intr": (9,),  # float32
+            "agent/rear_left/calib/extr": (16,), # float32
+            # rear camera
+            "agent/rear/img": (551, 972, 3),  # float32
+            "agent/rear/calib/intr": (9,),  # float32
+            "agent/rear/calib/extr": (16,), # float32
+            # rear right camera
+            "agent/rear_right/img": (587, 972, 3),  # float32
+            "agent/rear_right/calib/intr": (9,),  # float32
+            "agent/rear_right/calib/extr": (16,), # float32
+            # intent
+            "agent/intent": (1,), # float32
+            # current velocity
+            "agent/vel": (6,), # float32
+            # history
+            "history/agent/pose": (16,), # float32
+            "history/agent/pos": (16, 2), # float32
+            "history/agent/vel": (16, 2), # float32
+            "history/agent/acc": (16, 2), # float32
+            # total pos
+            "agent/pos": (36, 2),
+            # ground truth pos
+            "gt/pos": (20, 3),
+        }
+
+        self.tensor_size_test = {
+            # front left camera
+            "agent/front_left/img": (1079, 972, 3),  # float32
+            "agent/front_left/calib/intr": (9,),  # float32
+            "agent/front_left/calib/extr": (16,), # float32
+            # front camera
+            "agent/front/img": (1079, 972, 3),  # float32
+            "agent/front/calib/intr": (9,),  # float32
+            "agent/front/calib/extr": (16,), # float32
+            # front right camera
+            "agent/front_right/img": (1079, 972, 3),  # float32
+            "agent/front_right/calib/intr": (9,),  # float32
+            "agent/front_right/calib/extr": (16,), # float32
+            # side left camera
+            "agent/side_left/img": (1079, 972, 3),  # float32
+            "agent/side_left/calib/intr": (9,),  # float32
+            "agent/side_left/calib/extr": (16,), # float32
+            # side right camera
+            "agent/side_right/img": (1079, 972, 3),  # float32
+            "agent/side_right/calib/intr": (9,),  # float32
+            "agent/side_right/calib/extr": (16,), # float32
+            # rear left camera
+            "agent/rear_left/img": (587, 972, 3),  # float32
+            "agent/rear_left/calib/intr": (9,),  # float32
+            "agent/rear_left/calib/extr": (16,), # float32
+            # rear camera
+            "agent/rear/img": (551, 972, 3),  # float32
+            "agent/rear/calib/intr": (9,),  # float32
+            "agent/rear/calib/extr": (16,), # float32
+            # rear right camera
+            "agent/rear_right/img": (587, 972, 3),  # float32
+            "agent/rear_right/calib/intr": (9,),  # float32
+            "agent/rear_right/calib/extr": (16,), # float32
+            # intent
+            "agent/intent": (1,), # float32
+            # current velocity
+            "agent/vel": (6,), # float32
+            # history
+            "history/agent/pose": (16,), # float32
+            "history/agent/pos": (16, 2), # float32
+            "history/agent/vel": (16, 2), # float32
+            "history/agent/acc": (16, 2), # float32
+        }
+
+        self.tensor_size_val = {
+            "gt/preference_scores": (3,),
+        }
+
+        self.tensor_size_val = (
+            self.tensor_size_val | self.tensor_size_train | self.tensor_size_test
+        )
+
+    def setup(self, stage: Optional[str] = None) -> None:
+        if stage == "fit" or stage is None:
+            self.train_dataset = DatasetTrain(
+                self.path_train_h5, self.tensor_size_train
+            )
+            self.val_dataset = DatasetVal(self.path_val_h5, self.tensor_size_val)
+        elif stage == "validate":
+            self.val_dataset = DatasetVal(self.path_val_h5, self.tensor_size_val)
+        elif stage == "test":
+            self.test_dataset = DatasetVal(self.path_test_h5, self.tensor_size_test)
+        elif stage == "predict":
+            self.val_dataset = DatasetVal(self.path_val_h5, self.tensor_size_val)
+
+    def train_dataloader(self) -> DataLoader[Any]:
+        return self._get_dataloader(
+            self.train_dataset, self.batch_size, self.num_workers
+        )
+
+    def val_dataloader(self) -> DataLoader[Any]:
+        return self._get_dataloader(self.val_dataset, self.batch_size, self.num_workers)
+
+    def test_dataloader(self) -> DataLoader[Any]:
+        return self._get_dataloader(
+            self.test_dataset, self.batch_size, self.num_workers
+        )
+
+    def predict_dataloader(self) -> DataLoader[Any]:
+        return self._get_dataloader(self.val_dataset, self.batch_size, self.num_workers)
+
+    @staticmethod
+    def _get_dataloader(
+        ds: Dataset, batch_size: int, num_workers: int
+    ) -> DataLoader[Any]:
+        return DataLoader(
+            ds,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            pin_memory=True,
+            shuffle=False,
+            drop_last=False,
+            persistent_workers=True,
+        )

--- a/hptr_modules/data_modules/e2e_preprocessing.py
+++ b/hptr_modules/data_modules/e2e_preprocessing.py
@@ -8,10 +8,13 @@ class End2EndPreProcessing(nn.Module):
     def __init__(
         self,
         stitch_view: bool,
+        time_step_current: int,
+        data_size: DictConfig
     ) -> None:
         super().__init__()
 
         self.stitch_view = stitch_view
+        self.model_kwargs = {"e2e_model": True}
 
     def forward(self, batch: Dict[str, Tensor]) -> Dict[str, Tensor]:
         """
@@ -125,28 +128,30 @@ class End2EndPreProcessing(nn.Module):
                 dim=1
                 )
             
-        # Ego routing intent
-        batch["input/intent"] = batch["agent/intent"]
+        # Ego routing intent one hot
+        ohe = torch.eye(3).to(batch["agent/intent"].device)
+        batch["input/intent"] = batch["input/intent"] = ohe[batch["agent/intent"]-1]
 
-        # Ego twist at current step
+        # Ego twist at current step [batch_size, 6]
         batch["input/vel"] = batch["agent/vel"]
+        # vx, vy, vz, wx, wy, wz 
 
-        # Ego history trajectory
+        # Ego history trajectory [batch_size,16, 6]
         batch["input/ego_attr"] = torch.cat(
             [
                 batch["history/agent/pos"],
                 batch["history/agent/vel"],
-                batch["history/agent/acc"],
-                batch["history/agent/pose"]
+                batch["history/agent/acc"]
             ],
-            dim=1
-        )
+            dim=-1
+        ) # x, y, vx, vy, ax, az 
 
         # Check for ground truth (only in train & val)
+        # [batch_size, 20, 2] 
         if "gt/pos" in batch:
             batch["ref/pos"] = batch["gt/pos"]
 
-        # Check for rater scores (only in val)
+        # Check for rater scores (Not available!)
         if "gt/preference_scores" in batch:
             batch["ref/preference_scores"] = batch["gt/preference_scores"]
         

--- a/hptr_modules/data_modules/e2e_preprocessing.py
+++ b/hptr_modules/data_modules/e2e_preprocessing.py
@@ -1,0 +1,153 @@
+# Licensed under the CC BY-NC 4.0 license (https://creativecommons.org/licenses/by-nc/4.0/)
+from typing import Dict
+from omegaconf import DictConfig
+import torch
+from torch import nn, Tensor
+
+class End2EndPreProcessing(nn.Module):
+    def __init__(
+        self,
+        stitch_view: bool,
+    ) -> None:
+        super().__init__()
+
+        self.stitch_view = stitch_view
+
+    def forward(self, batch: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        """
+        Args: agent Dict
+            # ego view
+                agent/front_left/img: [batch_size, 1079, 972, 3]
+                agent/front_left/calib/intr: [batch_size, 9]
+                agent/front_left/calib/extr: [batch_size, 16]
+                agent/front/img: [batch_size, 1079, 972, 3]
+                agent/front/calib/intr: [batch_size, 9]
+                agent/front/calib/extr: [batch_size, 16]
+                agent/front_right/img: [batch_size, 1079, 972, 3]
+                agent/front_right/calib/intr: [batch_size, 9]
+                agent/front_right/calib/extr: [batch_size, 16]
+                agent/side_left/img: [batch_size, 1079, 972, 3]
+                agent/side_left/calib/intr: [batch_size, 9]
+                agent/side_left/calib/extr: [batch_size, 16]
+                agent/side_right/img: [batch_size, 1079, 972, 3]
+                agent/side_right/calib/intr: [batch_size, 9]
+                agent/side_right/calib/extr: [batch_size, 16]
+                agent/rear_left/img: [batch_size, 587, 972, 3]
+                agent/rear_left/calib/intr: [batch_size, 9]
+                agent/rear_left/calib/extr: [batch_size, 16]
+                agent/rear/img: [batch_size, 551, 972, 3]
+                agent/rear/calib/intr: [batch_size, 9]
+                agent/rear/calib/extr: [batch_size, 16]
+                agent/rear_right/img: [batch_size, 587, 972, 3]
+                agent/rear_right/calib/intr: [batch_size, 9]
+                agent/rear_right/calib/extr: [batch_size, 16]
+
+            # ego routing intent
+                agent/intent: [batch_size, 1]
+
+            # ego twist (current step linear and angular velocities)
+                agent/vel: [batch_size, 6]
+
+            # ego history
+                history/agent/pose: [batch_size, 16]
+                history/agent/pos: [batch_size, 16, 2]
+                history/agent/vel: [batch_size, 16, 2]
+                history/agent/acc: [batch_size, 16, 2]
+
+            # ego total traj
+                agent/pos: [batch_size, 36, 2]
+            
+            # rater scores
+                gt/preference_scores: [batch_size, 3]
+
+            # ego ground truth
+                gt/pos: [batch_size, 20, 3]
+
+        Returns: add following keys to batch Dict
+
+            # input images
+                input/front_left_img: [batch_size, 1079, 972, 3]
+                input/front_img: [batch_size, 1079, 972, 3]
+                input/front_right_img: [batch_size, 1079, 972, 3]
+                input/side_left_img: [batch_size, 1079, 972, 3]
+                input/side_right_img: [batch_size, 1079, 972, 3]
+                input/rear_left_img: [batch_size, 587, 972, 3]
+                input/rear_img: [batch_size, 551, 972, 3]
+                input/rear_right_img: [batch_size, 587, 972, 3]
+
+                input/stitched_img: [batch_size, 7120, 972, 3]
+
+            # input current status
+                input/intent: [batch_size]
+                input/vel: [batch_size, 6]
+
+            # input history trajectory
+                input/ego_attr: [batch_size, 16, 7]
+
+            # reference
+                ref/pos:  [batch_size, 20, 2]
+                ref/preference_scores: [batch_size, 3]
+
+        """
+
+        # Ego view at current step
+        batch["input/front_left_img"] = batch["agent/front_left/img"]
+        batch["input/front_img"] = batch["agent/front/img"]
+        batch["input/front_right_img"] = batch["agent/front_right/img"]
+        batch["input/side_left_img"] = batch["agent/side_left/img"]
+        batch["input/side_right_img"] = batch["agent/side_right/img"]
+        batch["input/rear_left_img"] = batch["agent/rear_left/img"]
+        batch["input/rear_img"] = batch["agent/rear/img"]
+        batch["input/rear_right_img"] = batch["agent/rear_right/img"]
+
+        if self.stitch_view:
+
+            #     stitching order 
+            #      _______________]______
+            #     |              ___  [2]\
+            #     [4]  /|    [3[|   \    |  forward
+            #     [5] | |       |    | [1]  ------>
+            #     [6]  \|    [7[|___/    |
+            #     |___________________[0]/
+            #                     ]
+
+            batch["input/stitched_img"] = torch.cat(
+                [
+                    batch["input/front_left_img"],
+                    batch["input/front_img"],
+                    batch["input/front_right_img"],
+                    batch["input/side_right_img"],
+                    batch["input/rear_right_img"],
+                    batch["input/rear_img"],
+                    batch["input/rear_left_img"],
+                    batch["input/side_left_img"],
+                ], 
+                dim=1
+                )
+            
+        # Ego routing intent
+        batch["input/intent"] = batch["agent/intent"]
+
+        # Ego twist at current step
+        batch["input/vel"] = batch["agent/vel"]
+
+        # Ego history trajectory
+        batch["input/ego_attr"] = torch.cat(
+            [
+                batch["history/agent/pos"],
+                batch["history/agent/vel"],
+                batch["history/agent/acc"],
+                batch["history/agent/pose"]
+            ],
+            dim=1
+        )
+
+        # Check for ground truth (only in train & val)
+        if "gt/pos" in batch:
+            batch["ref/pos"] = batch["gt/pos"]
+
+        # Check for rater scores (only in val)
+        if "gt/preference_scores" in batch:
+            batch["ref/preference_scores"] = batch["gt/preference_scores"]
+        
+        return batch

--- a/hptr_modules/data_modules/e2e_preprocessing.py
+++ b/hptr_modules/data_modules/e2e_preprocessing.py
@@ -104,11 +104,11 @@ class End2EndPreProcessing(nn.Module):
 
             #     stitching order 
             #      _______________]______
-            #     |              ___  [2]\
-            #     [4]  /|    [3[|   \    |  forward
+            #     |              ___  [0]\
+            #     [6]  /|    [7]|   \    |  forward
             #     [5] | |       |    | [1]  ------>
-            #     [6]  \|    [7[|___/    |
-            #     |___________________[0]/
+            #     [4]  \|    [3]|___/    |
+            #     |___________________[2]/
             #                     ]
 
             batch["input/stitched_img"] = torch.cat(


### PR DESCRIPTION
Added `data_h5_waymo_e2e.py ` and `e2e_preprocessing.py` to  support model training on the Waymo E2E Dataset.
Data is stored in h5 files packed with [this tool](https://github.com/JVPC0D3R/pack-waymo-e2e), following HPTR-ish naming style.

